### PR TITLE
Fix README path to match SWF filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Runs in any modern browser—no legacy plugins required.
 ```text
 dieai-flash/
 ├── assets/
-│   └── dieai.swf      # original Flash build
+│   └── DieAI.swf      # original Flash build
 ├── index.html         # Ruffle loader
 ├── README.md          # this file
 └── LICENSE            # MIT by default


### PR DESCRIPTION
## Summary
- correct the case of DieAI.swf in README

This fixes confusion about the asset name, which previously could lead to a missing file when the index tried loading the SWF.


------
https://chatgpt.com/codex/tasks/task_e_687573649978832b966722e708b8cd25